### PR TITLE
Bring up-to-date and gets specs passing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
 language: ruby
 rvm:
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
+  - 2.0.0-p598
+  - 2.1.5
+  - 2.2.1
+  - ruby-head
+  - mruby-head
+  - mruby-1.0.0
+  - jruby-head
+  - jruby-9.0.0.0.pre1
+  - jruby-1.7.19
   - jruby-18mode # JRuby in 1.8 mode
   - jruby-19mode # JRuby in 1.9 mode
-  - rbx-18mode
   - rbx-19mode
+  - rbx-2
+  - rbx-2.2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ rvm:
   - 2.1.5
   - 2.2.1
   - ruby-head
-  - mruby-head
-  - mruby-1.0.0
   - jruby-head
   - jruby-9.0.0.0.pre1
   - jruby-1.7.19

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,6 @@ group :development do
   gem "bundler"
   gem "jeweler", "~> 1.6.4"
   gem "simplecov", ">= 0"
-  gem "yajl-ruby", "~>0.8.2", :platforms => :mri
+  gem "yajl-ruby", "~>1.2", :platforms => :mri
   gem "json", "~>1.5.3", :platforms => :jruby
 end

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,7 @@
-Copyright (c) 2011 nolan frausto
+Original work copyright (c) 2011 nolan frausto
+
+The code in Resque::Plugins::Remora::PushPop::constantize is from the Rails source
+  Copyright © 2004-2013 David Heinemeier Hansson
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/Rakefile
+++ b/Rakefile
@@ -40,7 +40,7 @@ end
 
 task :default => :spec
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|
   version = File.exist?('VERSION') ? File.read('VERSION') : ""
 

--- a/lib/resque/plugins/remora/push_pop.rb
+++ b/lib/resque/plugins/remora/push_pop.rb
@@ -10,7 +10,7 @@ module Resque
           end
         end
 
-        module ClassMethods 
+        module ClassMethods
           def push(queue, item)
             job_class = constantize(item[:class])
             item = job_class.remora_attachment.merge(item) if remora_class?(job_class)
@@ -19,7 +19,7 @@ module Resque
 
           def pop(queue)
             job = original_pop(queue)
-            begin 
+            begin
               attachment = job['remora']
               job_class = constantize(job['class'])
               if !attachment.nil? && remora_class?(job_class)
@@ -29,11 +29,43 @@ module Resque
             end
             job
           end
-          
+
           private
-          
+
           def remora_class?(job_class)
             job_class && job_class.respond_to?(:process_remora) && job_class.respond_to?(:attach_remora) && job_class.respond_to?(:remora_attachment)
+          end
+
+          # From file activesupport/lib/active_support/inflector/methods.rb, line 226
+          def constantize(camel_cased_word)
+            names = camel_cased_word.split('::')
+
+            # Trigger a builtin NameError exception including the ill-formed constant in the message.
+            Object.const_get(camel_cased_word) if names.empty?
+
+            # Remove the first blank element in case of '::ClassName' notation.
+            names.shift if names.size > 1 && names.first.empty?
+
+            names.inject(Object) do |constant, name|
+              if constant == Object
+                constant.const_get(name)
+              else
+                candidate = constant.const_get(name)
+                next candidate if constant.const_defined?(name, false)
+                next candidate unless Object.const_defined?(name)
+
+                # Go down the ancestors to check it it's owned
+                # directly before we reach Object or the end of ancestors.
+                constant = constant.ancestors.inject do |const, ancestor|
+                  break const    if ancestor == Object
+                  break ancestor if ancestor.const_defined?(name, false)
+                  const
+                end
+
+                # owner is in Object, so raise
+                constant.const_get(name, false)
+              end
+            end
           end
         end
       end

--- a/spec/redis-test.conf
+++ b/spec/redis-test.conf
@@ -99,9 +99,9 @@ dbfilename dump.rdb
 #
 # The DB will be written inside this directory, with the filename specified
 # above using the 'dbfilename' configuration directive.
-# 
+#
 # Also the Append Only File will be created inside this directory.
-# 
+#
 # Note that you must specify a directory here, not a file name.
 dir ./spec/
 
@@ -142,7 +142,7 @@ slave-serve-stale-data yes
 #
 # This should stay commented out for backward compatibility and because most
 # people do not need auth (e.g. they run their own servers).
-# 
+#
 # Warning: since Redis is pretty fast an outside user can try up to
 # 150k passwords per second against a good box. This means that you should
 # use a very strong password otherwise it will be very easy to break.
@@ -196,14 +196,14 @@ slave-serve-stale-data yes
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
 # is reached? You can select among five behavior:
-# 
+#
 # volatile-lru -> remove the key with an expire set using an LRU algorithm
 # allkeys-lru -> remove any key accordingly to the LRU algorithm
 # volatile-random -> remove a random key with an expire set
 # allkeys->random -> remove a random key, any key
 # volatile-ttl -> remove the key with the nearest expire time (minor TTL)
 # noeviction -> don't expire at all, just return an error on write operations
-# 
+#
 # Note: with all the kind of policies, Redis will return an error on write
 #       operations, when there are not suitable keys for eviction.
 #
@@ -249,7 +249,7 @@ appendonly no
 # appendfilename appendonly.aof
 
 # The fsync() call tells the Operating System to actually write data on disk
-# instead to wait for more data in the output buffer. Some OS will really flush 
+# instead to wait for more data in the output buffer. Some OS will really flush
 # data on disk, some other OS will just try to do it ASAP.
 #
 # Redis supports three different modes:
@@ -287,91 +287,13 @@ appendfsync everysec
 # the same as "appendfsync none", that in pratical terms means that it is
 # possible to lost up to 30 seconds of log in the worst scenario (with the
 # default Linux settings).
-# 
+#
 # If you have latency problems turn this to "yes". Otherwise leave it as
 # "no" that is the safest pick from the point of view of durability.
 no-appendfsync-on-rewrite no
 
-################################ VIRTUAL MEMORY ###############################
-
-# Virtual Memory allows Redis to work with datasets bigger than the actual
-# amount of RAM needed to hold the whole dataset in memory.
-# In order to do so very used keys are taken in memory while the other keys
-# are swapped into a swap file, similarly to what operating systems do
-# with memory pages.
-#
-# To enable VM just set 'vm-enabled' to yes, and set the following three
-# VM parameters accordingly to your needs.
-
-vm-enabled no
-# vm-enabled yes
-
-# This is the path of the Redis swap file. As you can guess, swap files
-# can't be shared by different Redis instances, so make sure to use a swap
-# file for every redis process you are running. Redis will complain if the
-# swap file is already in use.
-#
-# The best kind of storage for the Redis swap file (that's accessed at random) 
-# is a Solid State Disk (SSD).
-#
-# *** WARNING *** if you are using a shared hosting the default of putting
-# the swap file under /tmp is not secure. Create a dir with access granted
-# only to Redis user and configure Redis to create the swap file there.
-vm-swap-file /tmp/redis.swap
-
-# vm-max-memory configures the VM to use at max the specified amount of
-# RAM. Everything that deos not fit will be swapped on disk *if* possible, that
-# is, if there is still enough contiguous space in the swap file.
-#
-# With vm-max-memory 0 the system will swap everything it can. Not a good
-# default, just specify the max amount of RAM you can in bytes, but it's
-# better to leave some margin. For instance specify an amount of RAM
-# that's more or less between 60 and 80% of your free RAM.
-vm-max-memory 0
-
-# Redis swap files is split into pages. An object can be saved using multiple
-# contiguous pages, but pages can't be shared between different objects.
-# So if your page is too big, small objects swapped out on disk will waste
-# a lot of space. If you page is too small, there is less space in the swap
-# file (assuming you configured the same number of total swap file pages).
-#
-# If you use a lot of small objects, use a page size of 64 or 32 bytes.
-# If you use a lot of big objects, use a bigger page size.
-# If unsure, use the default :)
-vm-page-size 32
-
-# Number of total memory pages in the swap file.
-# Given that the page table (a bitmap of free/used pages) is taken in memory,
-# every 8 pages on disk will consume 1 byte of RAM.
-#
-# The total swap size is vm-page-size * vm-pages
-#
-# With the default of 32-bytes memory pages and 134217728 pages Redis will
-# use a 4 GB swap file, that will use 16 MB of RAM for the page table.
-#
-# It's better to use the smallest acceptable value for your application,
-# but the default is large in order to work in most conditions.
-vm-pages 134217728
-
-# Max number of VM I/O threads running at the same time.
-# This threads are used to read/write data from/to swap file, since they
-# also encode and decode objects from disk to memory or the reverse, a bigger
-# number of threads can help with big objects even if they can't help with
-# I/O itself as the physical device may not be able to couple with many
-# reads/writes operations at the same time.
-#
-# The special value of 0 turn off threaded I/O and enables the blocking
-# Virtual Memory implementation.
-vm-max-threads 4
 
 ############################### ADVANCED CONFIG ###############################
-
-# Hashes are encoded in a special way (much more memory efficient) when they
-# have at max a given numer of elements, and the biggest element does not
-# exceed a given threshold. You can configure this limits with the following
-# configuration directives.
-hash-max-zipmap-entries 512
-hash-max-zipmap-value 64
 
 # Similarly to hashes, small lists are also encoded in a special way in order
 # to save a lot of space. The special representation is only used when
@@ -393,7 +315,7 @@ set-max-intset-entries 512
 # that is rhashing, the more rehashing "steps" are performed, so if the
 # server is idle the rehashing is never complete and some more memory is used
 # by the hash table.
-# 
+#
 # The default is to use this millisecond 10 times every second in order to
 # active rehashing the main dictionaries, freeing memory when possible.
 #

--- a/spec/redis-test.conf
+++ b/spec/redis-test.conf
@@ -46,10 +46,10 @@ timeout 300
 # warning (only very important / critical messages are logged)
 loglevel debug
 
-# Specify the log file name. Also 'stdout' can be used to force
+# Specify the log file name. Also the empty string can be used to force
 # Redis to log on the standard output. Note that if you use standard
 # output for logging but daemonize, logs will be sent to /dev/null
-logfile stdout
+logfile ""
 
 # To enable logging to the system logger, just set 'syslog-enabled' to yes,
 # and optionally update the other syslog parameters to suit your needs.

--- a/spec/resque/plugins/remora_spec.rb
+++ b/spec/resque/plugins/remora_spec.rb
@@ -2,35 +2,36 @@ require 'spec_helper'
 
 describe Resque::Plugins::Remora do
   subject { Resque::Plugins::Remora }
-  
+
   before do
     @now = Time.now
     Time.stub(:now => @now)
   end
-  
+
   it "should be a valid resque plugin" do
     Resque::Plugin.lint(Resque::Plugins::Remora)
   end
-  
+
   describe "#process_remora" do
-    
+
     before do
       @worker = Resque::Worker.new(:test)
+      @worker.term_child = true
     end
-    
+
     it "should process a remora job" do
       Resque.enqueue(TestJob, "arg1")
       @worker.work(0)
       Resque.redis.get("time").should == @now.to_i.to_s
       Resque.redis.get("queue").should == "test"
     end
-    
+
     it "should process multiple remora jobs with different arguments" do
       Resque.enqueue(TestJob, "arg1")
       now2 = Time.now
       Time.stub(:now => now2)
       Resque.enqueue(TestJob, "arg2")
-      
+
       @worker.work(0)
       Resque.redis.get(@now.to_i).should == "true"
       Resque.redis.get(now2.to_i).should == "true"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,10 +24,14 @@ dir = File.dirname(__FILE__)
 #
 
 at_exit do
-  pid = `ps -e -o pid,command | grep [r]edis-test`.split(" ")[0]
-  puts "Killing test redis server [#{pid}]..."
   `rm -f #{dir}/dump.rdb`
-  Process.kill("KILL", pid.to_i)
+  pid = `ps -e -o pid,command | grep [r]edis.*9736`.split(" ")[0]
+  if pid.to_i >= 100
+    puts "Killing test redis server [#{pid}]..."
+    Process.kill("KILL", pid.to_i)
+  else
+    puts "Found #{pid} for resque-server that is probably not resque, so not killing it."
+  end
 end
 
 puts "Starting redis for testing at localhost:9736..."


### PR DESCRIPTION
- Update `yajl` because of broken "Symbol not found" error
- Add missing #constantize method for PushPop (#2)
- Fix broken reference to rdoc/tasks for latest doc
- Remove redis configuration options that are no longer supported
- Fix resque worker to use new term_child method of signal handling
