### PR TITLE
Feature/defer to resque constantize method when defined

### DIFF
--- a/lib/resque/plugins/remora/push_pop.rb
+++ b/lib/resque/plugins/remora/push_pop.rb
@@ -30,8 +30,23 @@ module Resque
             job
           end
 
-          # From file activesupport/lib/active_support/inflector/methods.rb, line 226
+          # NOTE:
+          # Prior to Resque 1.26, Resque.constantize was not defined.  For
+          # 1.26 and after, overriding Resque.constantize causes compatibility
+          # issues.  So, for Resque < 1.26 we want to define a constantize
+          # method here.  For Resque >= 1.26 we do not.
           def constantize(camel_cased_word)
+            defined?(super) ? super(camel_cased_word) : _constantize(camel_cased_word)
+          end
+
+          private
+
+          def remora_class?(job_class)
+            job_class && job_class.respond_to?(:process_remora) && job_class.respond_to?(:attach_remora) && job_class.respond_to?(:remora_attachment)
+          end
+
+          # From file activesupport/lib/active_support/inflector/methods.rb, line 226
+          def _constantize(camel_cased_word)
             names = camel_cased_word.split('::')
 
             # Trigger a builtin NameError exception including the ill-formed constant in the message.
@@ -60,12 +75,6 @@ module Resque
                 constant.const_get(name, false)
               end
             end
-          end
-
-          private
-
-          def remora_class?(job_class)
-            job_class && job_class.respond_to?(:process_remora) && job_class.respond_to?(:attach_remora) && job_class.respond_to?(:remora_attachment)
           end
         end
       end

--- a/lib/resque/plugins/remora/push_pop.rb
+++ b/lib/resque/plugins/remora/push_pop.rb
@@ -30,12 +30,6 @@ module Resque
             job
           end
 
-          private
-
-          def remora_class?(job_class)
-            job_class && job_class.respond_to?(:process_remora) && job_class.respond_to?(:attach_remora) && job_class.respond_to?(:remora_attachment)
-          end
-
           # From file activesupport/lib/active_support/inflector/methods.rb, line 226
           def constantize(camel_cased_word)
             names = camel_cased_word.split('::')
@@ -66,6 +60,12 @@ module Resque
                 constant.const_get(name, false)
               end
             end
+          end
+
+          private
+
+          def remora_class?(job_class)
+            job_class && job_class.respond_to?(:process_remora) && job_class.respond_to?(:attach_remora) && job_class.respond_to?(:remora_attachment)
           end
         end
       end


### PR DESCRIPTION
## Problem

With Resque >= 1.26, you can expect the following errors from the following example.

**Example Test**:
```ruby
RSpec.describe 'Remora' do

  class TestRemoraJob
    extend Resque::Plugins::Remora

    @queue = :test_remora

    def attach_remora; end

    def process_remora(queue, attachment); end

    def self.perform; end
  end

  it do
    Resque.inline = true
    Resque.enqueue(TestRemoraJob)
  end
end
```

**Error**:
```
     NoMethodError:
       private method `constantize' called for Resque:Module
```

## Details

Resque 1.25.2 does not define `Resque.constantize`.  Resque >= 1.26 does and `Resque.constantize` is a public method.  The definition of `constantize` in the PushPop plugin and extension of the ClassMethods module is overriding `Resque.constantize`.  We want the best of both worlds.

## Solution

If `Resque.constantize` is defined, we will call it.  If not, we will use the `_constantize` method that is borrowed from ActiveSupport.

### Proof that it works

#### Resque 1.25.2

**Test**:
```ruby
RSpec.describe 'Remora' do

  class TestRemoraJob
    extend Resque::Plugins::Remora

    @queue = :test_remora

    def attach_remora; end

    def process_remora(queue, attachment); end

    def self.perform; end
  end

  it do
    Resque.inline = true
    Resque.enqueue(TestRemoraJob)
  end
end
```

**Debug Output**:
```
Calling constantize
Calling _constantize
```

#### Resque 1.26

**Test (same as above)**:
```ruby
RSpec.describe 'Remora' do

  class TestRemoraJob
    extend Resque::Plugins::Remora

    @queue = :test_remora

    def attach_remora; end

    def process_remora(queue, attachment); end

    def self.perform; end
  end

  it do
    Resque.inline = true
    Resque.enqueue(TestRemoraJob)
  end
end
```

**Debug Output**:
```
Calling constantize
```
(notice that we don't call `_constantize` in this case).