### PR TITLE
Expand resque requirement to include v2

### DIFF
--- a/resque-remora.gemspec
+++ b/resque-remora.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<resque>.freeze, ["~> 1.10"])
+      s.add_runtime_dependency(%q<resque>.freeze, [">= 1.10", "< 3.0"])
       s.add_development_dependency(%q<rspec>.freeze, [">= 0"])
       s.add_development_dependency(%q<bundler>.freeze, [">= 0"])
       s.add_development_dependency(%q<jeweler>.freeze, [">= 0"])
@@ -54,7 +54,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<yajl-ruby>.freeze, ["~> 1.2"])
       s.add_development_dependency(%q<json>.freeze, ["~> 1.5.3"])
     else
-      s.add_dependency(%q<resque>.freeze, ["~> 1.10"])
+      s.add_dependency(%q<resque>.freeze, [">= 1.10", "< 3.0"])
       s.add_dependency(%q<rspec>.freeze, [">= 0"])
       s.add_dependency(%q<bundler>.freeze, [">= 0"])
       s.add_dependency(%q<jeweler>.freeze, [">= 0"])
@@ -63,7 +63,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<json>.freeze, ["~> 1.5.3"])
     end
   else
-    s.add_dependency(%q<resque>.freeze, ["~> 1.10"])
+    s.add_dependency(%q<resque>.freeze, [">= 1.10", "< 3.0"])
     s.add_dependency(%q<rspec>.freeze, [">= 0"])
     s.add_dependency(%q<bundler>.freeze, [">= 0"])
     s.add_dependency(%q<jeweler>.freeze, [">= 0"])


### PR DESCRIPTION
## The Problem

We'd like to use `resque-remora`, but we are on `reque` v2.

## The Solution

Update the gemspec to allow any version of `resque` from 1.10 up to 3.0 (exclusive).  This fixes https://github.com/frausto/resque-remora/issues/5.

In doing some digging in resque, I've found that `push` and `pop` don't appear to have changed from v1 to v2.

Here is what it looks like in the [most recent v1 version](https://github.com/resque/resque/blob/f98cf438d5bf1701390cba4a56d4f5ced3129153/lib/resque.rb#L270-L272)

```ruby
  def push(queue, item)
    data_store.push_to_queue(queue,encode(item))
  end
```

Here is what it looks like in [master](https://github.com/resque/resque/blob/adb633a0f6b98b1eb5a5a85bb36ebac9309978fd/lib/resque.rb#L320-L322)

```ruby
  def push(queue, item)
    data_store.push_to_queue(queue,encode(item))
  end
```` 

In both versions, the `#encode` and `#pop` methods are also unchanged.

If we can push a release candidate version of the gem, we'd be happy to test it out and ensure it works in production systems.