### PR TITLE
Updating to test current versions of different rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-dist: trusty
 rvm:
   - 1.9
   - 2.0
@@ -11,14 +10,8 @@ rvm:
   - 2.6
   - 2.7
   - ruby-head
-  - jruby-head
-  - jruby-1.7
-  - jruby-9.0
   - jruby-9.1
   - jruby-9.2
+  - jruby-head
   - jruby-18mode # JRuby in 1.8 mode
   - jruby-19mode # JRuby in 1.9 mode
-  - rbx-19mode
-  - rbx-2
-  - rbx-3
-  - rbx-4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,23 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0-p598
-  - 2.1.5
-  - 2.2.1
+  - 1.9
+  - 2.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
   - ruby-head
   - jruby-head
-  - jruby-9.0.0.0.pre1
-  - jruby-1.7.19
+  - jruby-1.7
+  - jruby-9.0
+  - jruby-9.1
+  - jruby-9.2
   - jruby-18mode # JRuby in 1.8 mode
   - jruby-19mode # JRuby in 1.9 mode
   - rbx-19mode
   - rbx-2
-  - rbx-2.2.7
+  - rbx-3
+  - rbx-4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+dist: trusty
 rvm:
   - 1.9
   - 2.0


### PR DESCRIPTION
## The Problem

The ruby versions specified in the travis config file are out of date, and incomplete.

## The Solutions

Add missing versions, and update the current specifications to allow the most recent minor versions to be pulled in.

I'm not exactly sure what this file should look like.  This is my best guest.

### Open Questions

![Screen Shot 2019-12-13 at 12 16 08 PM](https://user-images.githubusercontent.com/441162/70822158-7bf85080-1da2-11ea-9101-9de82638efb9.png)
![Screen Shot 2019-12-13 at 12 16 15 PM](https://user-images.githubusercontent.com/441162/70822234-afd37600-1da2-11ea-9e09-89b5dd1536fc.png)

There were a few failing builds, for rubinius and jruby 1.7 and 9.0.  These all appear to be due to the default linux distro used by the build switching to Xenial.  
* [This issue](https://travis-ci.community/t/jruby-1-7-and-9-0-fail/4703) suggests that jruby-1.7 and jruby-9.0 aren't supported on Xenial
* [The docs](https://docs.travis-ci.com/user/languages/ruby/#rubinius) suggest that rubinius is only supported on Trusty

I tried switching the distribution used to trusty in https://github.com/frausto/resque-remora/pull/7/commits/e677c67110bd91b049fd5e2c26f0f52fe6225ba8.  This change resolved a few of the installation issues (not all), but also led to some test failures.  See [this build](https://travis-ci.org/frausto/resque-remora/builds/624736529) for the specifics.

I then pared down the versions and distributions we test against, completely removing rubinius, in https://github.com/frausto/resque-remora/pull/7/commits/77e9e60b26e24bc1c21548931b03df5cc35ee4b5.  The result was a green build!

**Are we okay with removing testing against rubinius, and two specific versions of jruby?**