### PR TITLE
Make base 'process_remora' the same arity as called

### DIFF
--- a/lib/resque/plugins/remora.rb
+++ b/lib/resque/plugins/remora.rb
@@ -6,7 +6,7 @@ module Resque
       end
       
       def attach_remora; {}; end
-      def process_remora; nil; end
+      def process_remora(_queue, _attachment); nil; end
     end
   end
 end


### PR DESCRIPTION
When chaining together multiple mixins that define a `process_remora` method using `super`, Remora chokes on the final call to `super` since it has a different arity. This only breaks places in tests where `process_remora` is explicitly called, since errors are swallowed in `pop`.

I've worked around it temporarily by doing the following:

```ruby
def process_remora(queue, attachment)
  # do stuff
  super if method(__method__).super_method.arity == 2
end
```